### PR TITLE
Add lookup API for materialized views

### DIFF
--- a/dataflow/graph.cc
+++ b/dataflow/graph.cc
@@ -25,12 +25,24 @@ bool DataFlowGraph::AddEdge(std::shared_ptr<Operator> op1,
   return res.second;
 }
 
-std::vector<std::shared_ptr<Operator>> DataFlowGraph::inputs() {
-  std::vector<std::shared_ptr<Operator>> v;
+std::vector<std::shared_ptr<InputOperator>> DataFlowGraph::inputs() {
+  std::vector<std::shared_ptr<InputOperator>> v;
 
   for (auto op : nodes_) {
     if (op.second->type() == OperatorType::INPUT) {
-      v.emplace_back(op.second);
+      v.emplace_back(std::static_pointer_cast<InputOperator>(op.second));
+    }
+  }
+
+  return v;
+}
+
+std::vector<std::shared_ptr<MatViewOperator>> DataFlowGraph::outputs() {
+  std::vector<std::shared_ptr<MatViewOperator>> v;
+
+  for (auto op : nodes_) {
+    if (op.second->type() == OperatorType::MAT_VIEW) {
+      v.emplace_back(std::static_pointer_cast<MatViewOperator>(op.second));
     }
   }
 

--- a/dataflow/graph.h
+++ b/dataflow/graph.h
@@ -6,6 +6,8 @@
 
 #include "dataflow/edge.h"
 #include "dataflow/operator.h"
+#include "dataflow/ops/input.h"
+#include "dataflow/ops/matview.h"
 
 namespace dataflow {
 
@@ -19,7 +21,8 @@ class DataFlowGraph {
   bool AddNode(OperatorType type, std::shared_ptr<Operator> op);
   bool AddEdge(std::shared_ptr<Operator> op1, std::shared_ptr<Operator> op2);
 
-  std::vector<std::shared_ptr<Operator>> inputs();
+  std::vector<std::shared_ptr<InputOperator>> inputs();
+  std::vector<std::shared_ptr<MatViewOperator>> outputs();
 
  private:
   absl::node_hash_map<NodeIndex, std::shared_ptr<Operator>> nodes_;

--- a/dataflow/graph_unittest.cc
+++ b/dataflow/graph_unittest.cc
@@ -33,13 +33,24 @@ TEST(DataFlowGraphTest, Construct) { DataFlowGraph g = makeGraph(); }
 TEST(DataFlowGraphTest, Basic) {
   DataFlowGraph g = makeGraph();
 
-  std::shared_ptr<Operator> in = g.inputs()[0];
+  std::shared_ptr<InputOperator> in = g.inputs()[0];
+  std::shared_ptr<MatViewOperator> out = g.outputs()[0];
 
   std::vector<Record> rs;
-  // rs.push_back();
+  RecordData key(42ULL);
 
-  std::vector<Record> out_rs;
-  EXPECT_TRUE(in->process(rs, out_rs));
+  std::vector<Record> proc_rs;
+
+  EXPECT_TRUE(in->process(rs, proc_rs));
+  // no records should have made it to the materialized view
+  EXPECT_EQ(out->lookup(key), std::vector<Record>());
+
+  std::vector<RecordData> rd = {key, RecordData(5ULL)};
+  Record r(true, rd, 0ULL);
+  rs.push_back(r);
+
+  EXPECT_TRUE(in->process(rs, proc_rs));
+  EXPECT_EQ(out->lookup(key), rs);
 }
 
 }  // namespace dataflow

--- a/dataflow/ops/input.h
+++ b/dataflow/ops/input.h
@@ -9,6 +9,7 @@
 namespace dataflow {
 
 class InputOperator : public Operator {
+ public:
   OperatorType type() override { return OperatorType::INPUT; }
   bool process(std::vector<Record>& rs, std::vector<Record>& out_rs) override;
 };

--- a/dataflow/ops/matview.cc
+++ b/dataflow/ops/matview.cc
@@ -29,4 +29,23 @@ bool MatViewOperator::process(std::vector<Record>& rs,
   return true;
 }
 
+std::vector<Record> MatViewOperator::lookup(const RecordData& key) const {
+  if (contents_.contains(key)) {
+    return contents_.at(key);
+  } else {
+    return std::vector<Record>();
+  }
+}
+
+std::vector<Record> MatViewOperator::multi_lookup(
+    std::vector<RecordData>& keys) {
+  std::vector<Record> out;
+  for (RecordData key : keys) {
+    if (contents_.contains(key)) {
+      // out.push_back(contents_.at(key));
+    }
+  }
+  return out;
+}
+
 }  // namespace dataflow

--- a/dataflow/ops/matview.h
+++ b/dataflow/ops/matview.h
@@ -20,6 +20,9 @@ class MatViewOperator : public Operator {
     // nothing to do
   }
 
+  std::vector<Record> lookup(const RecordData& key) const;
+  std::vector<Record> multi_lookup(std::vector<RecordData>& keys);
+
  private:
   // TODO(malte): should use Key type
   absl::flat_hash_map<RecordData, std::vector<Record>> contents_;


### PR DESCRIPTION
Also changes the interface of `Graph::inputs()`, `Graph::outputs()` to return pointers with the right types for inputs/materialized views.

Tests do not pass yet, as we lack the mechanics to process records through the dataflow.