### PR TITLE
Bug fix

### DIFF
--- a/pelton/dataflow/key.h
+++ b/pelton/dataflow/key.h
@@ -53,7 +53,7 @@ class Key {
       case sqlast::ColumnDefinition::Type::INT:
         return H::combine(std::move(h), k.sint_);
       case sqlast::ColumnDefinition::Type::TEXT:
-        return H::combine(std::move(h), k.str_.c_str(), k.str_.size());
+        return H::combine(std::move(h), k.str_, k.str_.size());
       default:
         LOG(FATAL) << "unimplemented pointed data hashing for Key";
     }


### PR DESCRIPTION
Keys that contain strings can now be inserted abseil flat hash maps. `c_str` includes [an additional null character at the end](http://www.cplusplus.com/reference/string/string/c_str/) which causes [this error](https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h#L1765).

This will also fix the aggregate branch.