### PR TITLE
Simplify linking of our JNI generator library

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -90,12 +90,6 @@ http_archive(
     urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
 )
 
-git_repository(
-    name = "gflags",
-    remote = "https://github.com/gflags/gflags.git",
-    tag = "v2.2.2",
-)
-
 # Google Benchmark library for microbenchmarks
 http_archive(
     name = "gbenchmark",
@@ -150,6 +144,7 @@ antlr(
 cc_library(
     name = "sqlparser",
     srcs = [":sqlgrammar"],
+    linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [
         ":sqlgrammar",

--- a/bin/BUILD.bazel
+++ b/bin/BUILD.bazel
@@ -5,10 +5,11 @@ cc_binary(
     srcs = [
         "example.cc",
     ],
+    linkstatic = 0,
     deps = [
         "//pelton",
         "//pelton/util:perf",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
         "@glog",
     ],
 )
@@ -18,11 +19,12 @@ cc_binary(
     srcs = [
         "cli.cc",
     ],
+    linkstatic = 0,
     deps = [
         "//pelton",
         "//pelton/util:latency",
         "//pelton/util:perf",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
         "@glog",
     ],
 )
@@ -38,7 +40,7 @@ cc_binary(
     deps = [
         "//pelton/util:latency",
         "//pelton/util:perf",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
         "@glog",
     ],
 )

--- a/pelton/dataflow/BUILD.bazel
+++ b/pelton/dataflow/BUILD.bazel
@@ -239,13 +239,14 @@ filegroup(
     visibility = ["//pelton:__subpackages__"],
 )
 
-cc_binary(
+cc_library(
     name = "generator",
     srcs = [
         "generator.cc",
+    ],
+    hdrs = [
         "generator.h",
     ],
-    linkshared = 1,
     visibility = ["//pelton:__subpackages__"],
     deps = [
         ":graph",

--- a/pelton/planner/BUILD.bazel
+++ b/pelton/planner/BUILD.bazel
@@ -18,6 +18,7 @@ cc_library(
     deps = [
         "//pelton/dataflow:graph",
         "//pelton/dataflow:state",
+        "//pelton/dataflow:generator",
         "//pelton/util:perf",
         "@bazel_tools//tools/jdk:jni",
         "@glog",
@@ -31,7 +32,6 @@ cc_test(
         "planner_unittest.cc",
     ],
     copts = ["-Iexternal/gtest/googletest/include"],
-    linkstatic = 1,
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/pelton/planner/calcite/src/com/brownsys/pelton/nativelib/BUILD.bazel
+++ b/pelton/planner/calcite/src/com/brownsys/pelton/nativelib/BUILD.bazel
@@ -21,7 +21,7 @@ genrule(
   # Remember where we should have been executing from within the bazel fs.
   EXEC_PATH=$$(pwd)
 
-  # Get the location of javacpp.jar, libgenerator.so, and include path.
+  # Get the location of javacpp.jar and include path.
   JAVACPP_JAR=$$(pwd)/$(location @maven//:org_bytedeco_javacpp)
   INCLUDE_PATH=$$(pwd)
 
@@ -52,7 +52,6 @@ genrule(
     name = "libjniDataFlowGraphLibrary_so",
     srcs = [
         ":DataDataFlowGraphLibrary_java",
-        "//pelton/dataflow:generator",
         "//pelton/dataflow:generator_h",
         "DataFlowGraphLibraryConfig.java",
     ],
@@ -69,11 +68,10 @@ genrule(
     READ_PATH=$$(dirname $${READ_PATH})
   done
   READ_PATH=$$(dirname $${READ_PATH})/execroot/pelton
-  # Get the location of javacpp.jar, libgenerator.so, and include path.
-  JAVACPP_JAR=$$(pwd)/$(location @maven//:org_bytedeco_javacpp)
-  LINK_PATH=$${READ_PATH}/$$(dirname $(location //pelton/dataflow:generator))
-  echo $${LINK_PATH}
+  # Find the include path (for headers).
   INCLUDE_PATH=$$(pwd)
+  # Get the location of javacpp.jar.
+  JAVACPP_JAR=$$(pwd)/$(location @maven//:org_bytedeco_javacpp)
 
   # Create a clean tmp directory and copy input files to it.
   TMP_DIR="/tmp/__libjniDataFlowGraphLibrary_so_tmp"
@@ -88,7 +86,6 @@ genrule(
   java -jar "$${JAVACPP_JAR}"                 \
       -nodelete                               \
       -Dplatform.includepath=$${INCLUDE_PATH} \
-      -Dplatform.linkpath=$${LINK_PATH}       \
       -Dplatform.compiler=gcc                 \
       com/brownsys/pelton/nativelib/DataFlowGraphLibrary.java
 

--- a/pelton/planner/calcite/src/com/brownsys/pelton/nativelib/DataFlowGraphLibraryConfig.java
+++ b/pelton/planner/calcite/src/com/brownsys/pelton/nativelib/DataFlowGraphLibraryConfig.java
@@ -17,8 +17,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
               "pelton/dataflow/ops/join_enum.h",
               "pelton/sqlast/ast_schema_enums.h",
               "pelton/dataflow/generator.h"
-            },
-            link = {"generator"}),
+            }),
     target = "com.brownsys.pelton.nativelib.DataFlowGraphLibrary")
 public class DataFlowGraphLibraryConfig implements InfoMapper {
   public void map(InfoMap infoMap) {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -91,11 +91,10 @@ cc_test(
         "//tests/data:trivial-queries.sql",
         "//tests/data:trivial-schema.sql",
     ],
-    linkstatic = 1,
     deps = [
         "//pelton",
         "//pelton/util:perf",
-        "@gflags",
+        "@com_github_gflags_gflags//:gflags",
         "@glog",
         "@gtest",
     ],


### PR DESCRIPTION
* javacpp produces incomplete .so that creates wrappers around functions declared in generator.h
* javacpp so is loaded by JVM at runtime
* symbols used by the javacpp so are defined in the host binary, as it deps and links with the actual libgenerator.so
* sqlparser library turned into a static library always to avoid known issue with antlr rules
* our binaries always use shared linking so that the symbols in generator.h are visible to JVM