### PR TITLE
View materialization

### DIFF
--- a/bin/examples/medical_chat.sql
+++ b/bin/examples/medical_chat.sql
@@ -36,8 +36,6 @@ CREATE TABLE chat (
   FOREIGN KEY (doctor_id) REFERENCES doctors(id)
 );
 
-CREATE VIEW v1 AS '"SELECT doctors.PII_name, patients.PII_name FROM doctors JOIN chat ON doctors.id = chat.doctor_id JOIN patients ON chat.OWNER_patient_id = patients.id"';
-
 INSERT INTO doctors VALUES (1, 'Alice');
 INSERT INTO doctors(id, PII_name) VALUES (2, 'Bob');
 
@@ -63,9 +61,20 @@ SELECT * FROM chat WHERE OWNER_patient_id = 10;
 GDPR GET patients 10;
 GDPR GET doctors 2;
 
+-- Test view creation after inserts.
+CREATE VIEW v1 AS '"SELECT doctors.PII_name, patients.PII_name FROM doctors JOIN chat ON doctors.id = chat.doctor_id JOIN patients ON chat.OWNER_patient_id = patients.id"';
+SELECT * FROM v1;
+
 DELETE FROM doctors WHERE id = 2;
+GDPR FORGET doctors 1;
 SELECT * FROM chat;
 
 GDPR FORGET patients 10;
 SELECT * FROM patients;
 SELECT * FROM chat;
+
+SELECT * FROM v1;
+
+SHOW MEMORY;
+SHOW VIEW v1;
+SHOW SHARDS;

--- a/mysql_proxy/src/BUILD.bazel
+++ b/mysql_proxy/src/BUILD.bazel
@@ -2,11 +2,12 @@ load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library")
 
 config_setting(
     name = "asan",
-    values = { "copt": "-DPELTON_ASAN" }
+    values = {"copt": "-DPELTON_ASAN"},
 )
+
 config_setting(
     name = "tsan",
-    values = { "copt": "-DPELTON_TSAN" }
+    values = {"copt": "-DPELTON_TSAN"},
 )
 
 rust_binary(
@@ -21,9 +22,15 @@ rust_binary(
         "-Clink-args=-rdynamic",
         "-Clink-args=-Wl,-export-dynamic",
     ] + select({
-        ":asan": ["-Clink-args=-fsanitize=address", "-Zsanitizer=address"],
-        ":tsan": ["-Clink-args=-fsanitize=thread", "-Zsanitizer=thread"],
-        "//conditions:default": []
+        ":asan": [
+            "-Clink-args=-fsanitize=address",
+            "-Zsanitizer=address",
+        ],
+        ":tsan": [
+            "-Clink-args=-fsanitize=thread",
+            "-Zsanitizer=thread",
+        ],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = [

--- a/pelton/dataflow/state.h
+++ b/pelton/dataflow/state.h
@@ -73,8 +73,13 @@ class DataFlowState {
   // Process raw data from sharder and use it to update flows.
   Record CreateRecord(const sqlast::Insert &insert_stmt) const;
 
+  // Process raw data from sharder and use it to update flows.
   void ProcessRecords(const TableName &table_name,
                       std::vector<Record> &&records);
+
+  void ProcessRecordsByFlowName(const FlowName &flow_name,
+                                const TableName &table_name,
+                                std::vector<Record> &&records);
 
   sql::SqlResult SizeInMemory() const;
   sql::SqlResult FlowDebug(const std::string &flow_name) const;

--- a/pelton/shards/sqlengine/BUILD.bazel
+++ b/pelton/shards/sqlengine/BUILD.bazel
@@ -208,6 +208,10 @@ cc_library(
     ],
     hdrs = [
         "view.h",
+        # We can't include :select as a dependency.
+        # It creates a cycle (select -> index -> view -> select).
+        # We can split these files better later.
+        "select.h",
     ],
     deps = [
         "//pelton:connection",

--- a/pelton/shards/sqlengine/engine.cc
+++ b/pelton/shards/sqlengine/engine.cc
@@ -65,7 +65,7 @@ absl::StatusOr<sql::SqlResult> Shard(const std::string &sql,
       if (dataflow_state->HasFlow(stmt->table_name())) {
         return view::SelectView(*stmt, connection);
       } else {
-        return select::Shard(*stmt, connection);
+        return select::Shard(*stmt, connection, true);
       }
     }
 

--- a/pelton/shards/sqlengine/select.cc
+++ b/pelton/shards/sqlengine/select.cc
@@ -56,11 +56,14 @@ dataflow::SchemaRef ResultSchema(const sqlast::Select &stmt,
 }  // namespace
 
 absl::StatusOr<sql::SqlResult> Shard(const sqlast::Select &stmt,
-                                     Connection *connection) {
+                                     Connection *connection, bool synchronize) {
   perf::Start("Select");
   shards::SharderState *state = connection->state->sharder_state();
   dataflow::DataFlowState *dataflow_state = connection->state->dataflow_state();
-  SharedLock lock = state->ReaderLock();
+  SharedLock lock;
+  if (synchronize) {
+    lock = state->ReaderLock();
+  }
 
   // Disqualifiy LIMIT and OFFSET queries.
   if (!stmt.SupportedByShards()) {

--- a/pelton/shards/sqlengine/select.h
+++ b/pelton/shards/sqlengine/select.h
@@ -17,7 +17,7 @@ namespace sqlengine {
 namespace select {
 
 absl::StatusOr<sql::SqlResult> Shard(const sqlast::Select &stmt,
-                                     Connection *connection);
+                                     Connection *connection, bool synchronize);
 
 }  // namespace select
 }  // namespace sqlengine

--- a/pelton/shards/sqlengine/update.cc
+++ b/pelton/shards/sqlengine/update.cc
@@ -124,10 +124,8 @@ absl::StatusOr<sql::SqlResult> Shard(const sqlast::Update &stmt,
   std::vector<dataflow::Record> records;
   size_t old_records_size = 0;
   if (update_flows) {
-    // NOTE(malte): select::Shard() takes another reader lock on the sharder
-    // state, but this is fine as that lock is never upgraded.
     MOVE_OR_RETURN(sql::SqlResult domain_result,
-                   select::Shard(stmt.SelectDomain(), connection));
+                   select::Shard(stmt.SelectDomain(), connection, false));
     records = domain_result.NextResultSet()->Vectorize();
     old_records_size = records.size();
     CHECK_STATUS(UpdateRecords(&records, stmt, state->GetSchema(table_name)));

--- a/pelton/shards/upgradable_lock.h
+++ b/pelton/shards/upgradable_lock.h
@@ -38,6 +38,7 @@ struct UpgradableMutex {
 // Class is movable but not copyable.
 class SharedLock {
  public:
+  SharedLock() = default;
   // Shared lock from scratch.
   explicit SharedLock(UpgradableMutex *mutex);
   // Shared lock by downgrading from a UniqueLock.

--- a/tests/data/medical/queries.sql
+++ b/tests/data/medical/queries.sql
@@ -9,3 +9,8 @@ SELECT 1, 'str' FROM chat WHERE doctor_id = 2;
 
 SELECT * FROM chat WHERE message IN ('HELLO', 'Good bye');
 SELECT * FROM chat WHERE doctor_id IN (2);
+
+SELECT * FROM address_doctors;
+SELECT * FROM city_doctor_count;
+SELECT * FROM patient_info;
+SELECT * FROM doctor_info;

--- a/tests/data/medical/queries.txt
+++ b/tests/data/medical/queries.txt
@@ -32,3 +32,16 @@ HELLO 3|20
 2|10|2|Good bye
 4|20|2|HELLO 2
 ;
+1|1|Boston
+2|1|Providence
+3|2|Damascus
+;
+Boston|1
+Damascus|1
+Providence|1
+;
+
+;
+1|Alice|1|Boston
+2|Bob|1|Providence
+;

--- a/tests/data/medical/views.sql
+++ b/tests/data/medical/views.sql
@@ -1,0 +1,4 @@
+CREATE VIEW city_doctor_count AS '"SELECT address_doctors.city, COUNT(*) AS `count` FROM address_doctors GROUP BY address_doctors.city"';
+CREATE VIEW city_patient_count AS '"SELECT address_patients.city, COUNT(*) AS `count` FROM address_patients GROUP BY address_patients.city"';
+CREATE VIEW patient_info AS '"SELECT * FROM patients INNER JOIN address_patients ON patients.id = address_patients.id"';
+CREATE VIEW doctor_info AS '"SELECT * FROM doctors INNER JOIN address_doctors ON doctors.id = address_doctors.id"';

--- a/tests/medical.cc
+++ b/tests/medical.cc
@@ -5,7 +5,7 @@ TEST(E2ECorrectnessTest, MedicalChat) {
 }
 
 int main(int argc, char **argv) {
-  return tests::TestingMain(argc, argv, "medical", 2,
-                            "tests/data/medical/schema.sql",
-                            "tests/data/medical/inserts.sql");
+  return tests::TestingMain(
+      argc, argv, "medical", 3, "tests/data/medical/schema.sql",
+      "tests/data/medical/inserts.sql", "tests/data/medical/views.sql");
 }


### PR DESCRIPTION
### Code:
- Refactored ProcessRecords in pelton/dataflow/state.cc to call ProcessRecordsByFlowName (allows updating specific flows with records from a table)
- Upon creation of new view in pelton/shards/sqlengine/view.cc, populate view with existing data in tables

### Tests:
**Lobsters**
 - Changed order in which views are created in tests/lobsters.cc
**Medical**
- Added views.sql to create two views of patient and doctor data (tests/data/medical/views.sql)
- Added tests to check these views are initialized correctly (tests/data/medical/queries.sql)

### Build:
- Changed pelton/shards/sqlengine/BUILD.bazel to allow select to be a dependency of view