### PR TITLE
Fix EXPLAIN

### DIFF
--- a/experiments/explain/invited_users.sql
+++ b/experiments/explain/invited_users.sql
@@ -1,0 +1,12 @@
+CREATE DATA_SUBJECT TABLE users (
+  id INT PRIMARY KEY,
+  email TEXT
+);
+
+CREATE DATA_SUBJECT TABLE invited_users (
+  id INT PRIMARY KEY,
+  email TEXT,
+  inviting_user INT OWNED_BY users(id)
+);
+
+EXPLAIN COMPLIANCE;

--- a/experiments/explain/ownCloud.sql
+++ b/experiments/explain/ownCloud.sql
@@ -1,80 +1,90 @@
-CREATE TABLE oc_files (
-  id INTEGER PRIMARY KEY NOT NULL,
-  file_name VARCHAR(255)
+-- Free/unsharded table.
+CREATE TABLE oc_storages (
+  id VARCHAR(64) ,
+  numeric_id INT,
+  available INT,
+  last_checked INT,
+  PRIMARY KEY (numeric_id)
 );
 
-CREATE TABLE  oc_users (
-  uid VARCHAR(64) NOT NULL,
-  PII_displayname VARCHAR(64),
-  password VARCHAR(255) NOT NULL,
+-- Sharded tables.
+CREATE DATA_SUBJECT TABLE oc_users (
+  uid VARCHAR(64),
+  displayname VARCHAR(64),
+  password VARCHAR(255),
   PRIMARY KEY(uid)
 );
 
-
 CREATE TABLE oc_groups (
-  gid VARCHAR(64) NOT NULL,
+  gid VARCHAR(64),
   PRIMARY KEY(gid)
 );
 
 CREATE TABLE oc_group_user (
   id INT PRIMARY KEY,
-  OWNING_gid VARCHAR(64) NOT NULL REFERENCES oc_groups(gid),
-  uid VARCHAR(64) NOT NULL REFERENCES oc_users(uid)
-  --UNIQUE group_user_uniq(OWNED_gid, uid)
+  gid VARCHAR(64) OWNS oc_groups(gid),
+  uid VARCHAR(64) OWNED_BY oc_users(uid)
 );
 
-CREATE VIEW users_for_group AS 
-'"SELECT oc_group_user.OWNING_gid, oc_group_user.uid, COUNT(*)
-FROM oc_group_user 
-WHERE oc_group_user.OWNING_gid = ?
-GROUP BY (oc_group_user.OWNING_gid, oc_group_user.uid)
-HAVING COUNT(*) > 0"' ;
+CREATE TABLE oc_files (
+  id INTEGER PRIMARY KEY,
+  file_name VARCHAR(255)
+);
 
 CREATE TABLE oc_share (
-  id INT NOT NULL PRIMARY KEY,
-  share_type INT NOT NULL,
-  ACCESSOR_share_with VARCHAR(255) REFERENCES oc_users(uid),
-  OWNER_share_with_group VARCHAR(255) REFERENCES oc_groups(gid),
-  OWNER_uid_owner VARCHAR(64) NOT NULL REFERENCES oc_users(uid),
+  id INT PRIMARY KEY,
+  share_type INT,
+  share_with VARCHAR(255) OWNED_BY oc_users(uid),
+  share_with_group VARCHAR(255) OWNED_BY oc_groups(gid),
+  uid_owner VARCHAR(64) OWNED_BY oc_users(uid),
   uid_initiator VARCHAR(64) REFERENCES oc_users(uid),
   parent INT ,
-  item_type VARCHAR(64) NOT NULL ,
-  OWNING_item_source INTEGER NOT NULL REFERENCES oc_files(id),
+  item_type VARCHAR(64) ,
+  item_source INTEGER OWNS oc_files(id),
   item_target VARCHAR(255),
   file_target VARCHAR(512),
-  permissions INT NOT NULL,
-  stime INT NOT NULL,
-  accepted INT NOT NULL,
+  permissions INT,
+  stime INT,
+  accepted INT,
   expiration DATETIME ,
   token VARCHAR(32),
-  mail_send INT NOT NULL,
+  mail_send INT,
   share_name VARCHAR(64),
   file_source INT,
   attributes TEXT
 );
 
-SET echo;
-
-
--- CREATE VIEW users_for_file_via_group AS 
--- '"SELECT oc_share.OWNING_item_source, oc_group_user.uid, COUNT(*)
--- FROM oc_share
--- JOIN oc_group_user ON oc_share.OWNER_share_with_group = oc_group_user.OWNING_gid
--- WHERE oc_share.OWNING_item_source = ?
--- GROUP BY (oc_share.OWNING_item_source, oc_group_user.uid)"';
+CREATE TABLE oc_filecache (
+  fileid INTEGER PRIMARY KEY OWNED_BY oc_files(id),
+  storage INTEGER REFERENCES oc_storages(numeric_id),
+  path VARCHAR(4000),
+  path_hash VARCHAR(32),
+  parent INT,
+  name VARCHAR(250),
+  mimetype INTEGER,
+  mimepart INTEGER,
+  size INT,
+  encrypted INTEGER,
+  unencrypted_size INT,
+  etag VARCHAR(40),
+  permissions INTEGER,
+  checksum VARCHAR(255),
+  mtime INT,
+  storage_mtime INT
+);
 
 
 -- CREATE VIEW file_view AS 
--- '"(SELECT s.id as sid, s.OWNING_item_source, s.share_type, s.ACCESSOR_share_with as share_target
+-- '"(SELECT s.id as sid, s.item_source, s.share_type, s.share_with as share_target
 -- FROM oc_share s
--- WHERE (s.share_type = 0) AND s.ACCESSOR_share_with = ?)
+-- WHERE (s.share_type = 0) AND s.share_with = ?)
 -- UNION
--- (SELECT s.id as sid, s.OWNING_item_source, s.share_type, oc_group_user.uid as share_target
+-- (SELECT s.id as sid, s.item_source, s.share_type, oc_group_user.uid as share_target
 -- FROM oc_share s
--- JOIN oc_group_user ON s.ACCESSOR_share_with_group = oc_group_user.OWNING_gid
+-- JOIN oc_group_user ON s.share_with_group = oc_group_user.gid
 -- WHERE (s.share_type = 1) AND oc_group_user.uid = ?
 --    )
 -- ORDER BY sid ASC
 -- "';
 
-EXPLAIN PRIVACY;
+EXPLAIN COMPLIANCE;

--- a/experiments/explain/shuup/auth-user-and-contact-is-pii.sql
+++ b/experiments/explain/shuup/auth-user-and-contact-is-pii.sql
@@ -1,15 +1,13 @@
-CREATE TABLE auth_user ( \
+CREATE DATA_SUBJECT TABLE auth_user ( \
   id int, \
-  ptr int, \
-  PII_username text, \
+  username text, \
   password text, \
   PRIMARY KEY(id) \
 );
 
-CREATE TABLE shuup_contact ( \
+CREATE DATA_SUBJECT TABLE shuup_contact ( \
   id int, \
-  ptr int, \
-  PII_name text, \
+  name text, \
   email text, \
   PRIMARY KEY(id) \
 );
@@ -17,45 +15,41 @@ CREATE TABLE shuup_contact ( \
 
 CREATE TABLE shuup_personcontact ( \
   pid int, \
-  OWNING_contact_ptr_id int NOT NULL REFERENCES shuup_contact(ptr), \
+  contact_ptr_id int NOT NULL OWNED_BY shuup_contact(id), \
   name text, \
-  OWNER_user_id int REFERENCES auth_user(ptr), \
+  user_id int OWNED_BY auth_user(id), \
   PRIMARY KEY(pid) \
 );
 
-CREATE INDEX personcontact_ptr ON shuup_personcontact(pid);
-
 CREATE TABLE shuup_companycontact ( \
-  contact_ptr_id int NOT NULL REFERENCES shuup_contact(ptr), \
+  contact_ptr_id int NOT NULL REFERENCES shuup_contact(id), \
   tax_number int, \
   PRIMARY KEY(contact_ptr_id) \
 );
 
-
 CREATE TABLE shuup_companycontact_members ( \
   id int, \
   companycontact_id int NOT NULL, \
-  OWNER_contact_id int REFERENCES shuup_personcontact(pid), \
+  contact_id int OWNED_BY shuup_personcontact(pid), \
   PRIMARY KEY (id), \
   FOREIGN KEY (companycontact_id) REFERENCES shuup_companycontact(contact_ptr_id) \
 );
 
 CREATE TABLE shuup_shop ( \
   id int, \
-  OWNER_owner_id int NOT NULL, \
+  owner_id int NOT NULL, \
   PRIMARY KEY (id), \
-  FOREIGN KEY (OWNER_owner_id) REFERENCES auth_user(id) \
+  FOREIGN KEY (owner_id) OWNED_BY auth_user(id) \
 );
-CREATE INDEX shuup_shop_id ON shuup_shop(id);
 
 CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   id int, \
   created_on datetime, \
   shop_id int NOT NULL, \
-  OWNER_user_id int NOT NULL, \
+  user_id int NOT NULL, \
   FOREIGN KEY (shop_id) REFERENCES shuup_shop(id), \
-  FOREIGN KEY (OWNER_user_id) REFERENCES auth_user(id), \
+  FOREIGN KEY (user_id) OWNED_BY auth_user(id), \
   PRIMARY KEY (id) \
 );
 
-EXPLAIN PRIVACY;
+EXPLAIN COMPLIANCE;

--- a/experiments/explain/shuup/auth-user-is-pii.sql
+++ b/experiments/explain/shuup/auth-user-is-pii.sql
@@ -1,7 +1,7 @@
-CREATE TABLE auth_user ( \
+CREATE DATA_SUBJECT TABLE auth_user ( \
   id int, \
   ptr int, \
-  PII_username text, \
+  username text, \
   password text, \
   PRIMARY KEY(id) \
 );
@@ -23,10 +23,8 @@ CREATE TABLE shuup_personcontact ( \
   user_id int, \
   PRIMARY KEY(pid), \
   FOREIGN KEY (contact_ptr_id) REFERENCES shuup_contact(ptr), \
-  FOREIGN KEY (user_id) REFERENCES auth_user(ptr) \
+  FOREIGN KEY (user_id) REFERENCES auth_user(id) \
 );
-
-CREATE INDEX auth_user_ptr ON auth_user(id);
 
 CREATE TABLE shuup_companycontact ( \
   contact_ptr_id int NOT NULL, \
@@ -37,28 +35,27 @@ CREATE TABLE shuup_companycontact ( \
 CREATE TABLE shuup_companycontact_members ( \
   id int, \
   companycontact_id int NOT NULL, \
-  ACCESSOR_contact_id int, \
+  contact_id int, \
   PRIMARY KEY (id), \
   FOREIGN KEY (companycontact_id) REFERENCES shuup_companycontact(contact_ptr_id), \
-  FOREIGN KEY (ACCESSOR_contact_id) REFERENCES shuup_personcontact(pid) \
+  FOREIGN KEY (contact_id) ACCESSED_BY shuup_personcontact(pid) \
 );
 
 CREATE TABLE shuup_shop ( \
   id int, \
-  OWNER_owner_id int NOT NULL, \
+  owner_id int NOT NULL, \
   PRIMARY KEY (id), \
-  FOREIGN KEY (OWNER_owner_id) REFERENCES auth_user(id) \
+  FOREIGN KEY (owner_id) OWNED_BY auth_user(id) \
 );
-CREATE INDEX shuup_shop_id ON shuup_shop(id);
 
 CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   id int, \
   created_on datetime, \
   shop_id int NOT NULL, \
-  OWNER_user_id int NOT NULL, \
+  user_id int NOT NULL, \
   FOREIGN KEY (shop_id) REFERENCES shuup_shop(id), \
-  FOREIGN KEY (OWNER_user_id) REFERENCES auth_user(id), \
+  FOREIGN KEY (user_id) OWNED_BY auth_user(id), \
   PRIMARY KEY (id) \
 );
 
-EXPLAIN PRIVACY;
+EXPLAIN COMPLIANCE;

--- a/experiments/explain/shuup/base.sql
+++ b/experiments/explain/shuup/base.sql
@@ -26,8 +26,6 @@ CREATE TABLE shuup_personcontact ( \
   FOREIGN KEY (OWNING_user_id) REFERENCES auth_user(ptr) \
 );
 
-CREATE INDEX auth_user_ptr ON auth_user(id);
-
 CREATE TABLE shuup_companycontact ( \
   contact_ptr_id int, \
   tax_number int, \
@@ -49,7 +47,6 @@ CREATE TABLE shuup_shop ( \
   PRIMARY KEY (id), \
   FOREIGN KEY (OWNER_owner_id) REFERENCES auth_user(id) \
 );
-CREATE INDEX shuup_shop_id ON shuup_shop(id);
 
 CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   id int, \

--- a/experiments/explain/shuup/contact-is-pii.sql
+++ b/experiments/explain/shuup/contact-is-pii.sql
@@ -6,10 +6,10 @@ CREATE TABLE auth_user ( \
   PRIMARY KEY(id) \
 );
 
-CREATE TABLE shuup_contact ( \
+CREATE DATA_SUBJECT TABLE shuup_contact ( \
   id int, \
   ptr int, \
-  PII_name text, \
+  name text, \
   PRIMARY KEY(id) \
 );
 
@@ -19,49 +19,44 @@ CREATE TABLE shuup_personcontact ( \
   pid int, \
   contact_ptr_id int NOT NULL, \
   name text, \
-  OWNING_user_id int, \
+  user_id int, \
   email text, \
   PRIMARY KEY(pid), \
-  FOREIGN KEY (contact_ptr_id) REFERENCES shuup_contact(ptr), \
-  FOREIGN KEY (OWNING_user_id) REFERENCES auth_user(ptr) \
+  FOREIGN KEY (contact_ptr_id) REFERENCES shuup_contact(id), \
+  FOREIGN KEY (user_id) OWNS auth_user(id) \
 );
-
-CREATE INDEX auth_user_ptr ON auth_user(id);
 
 CREATE TABLE shuup_companycontact ( \
   id int PRIMARY KEY,
   contact_ptr_id int NOT NULL, \
   tax_number int, \
-  FOREIGN KEY (contact_ptr_id) REFERENCES shuup_contact(ptr) \
+  FOREIGN KEY (contact_ptr_id) REFERENCES shuup_contact(id) \
 );
-
-CREATE INDEX company_contact_ptr_id ON shuup_companycontact(id);
 
 CREATE TABLE shuup_companycontact_members ( \
   id int, \
   companycontact_id int NOT NULL, \
-  ACCESSOR_contact_id int, \
+  contact_id int, \
   PRIMARY KEY (id), \
   FOREIGN KEY (companycontact_id) REFERENCES shuup_companycontact(id), \
-  FOREIGN KEY (ACCESSOR_contact_id) REFERENCES shuup_personcontact(pid) \
+  FOREIGN KEY (contact_id) ACCESSED_BY shuup_personcontact(pid) \
 );
 
 CREATE TABLE shuup_shop ( \
   id int, \
-  OWNER_owner_id int NOT NULL, \
+  owner_id int NOT NULL, \
   PRIMARY KEY (id), \
-  FOREIGN KEY (OWNER_owner_id) REFERENCES auth_user(id) \
+  FOREIGN KEY (owner_id) OWNED_BY auth_user(id) \
 );
-CREATE INDEX shuup_shop_id ON shuup_shop(id);
 
 CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   id int, \
   created_on datetime, \
   shop_id int, \
-  OWNER_user_id int NOT NULL, \
+  user_id int NOT NULL, \
   FOREIGN KEY (shop_id) REFERENCES shuup_shop(id), \
-  FOREIGN KEY (OWNER_user_id) REFERENCES auth_user(id), \
+  FOREIGN KEY (user_id) OWNED_BY auth_user(id), \
   PRIMARY KEY (id) \
 );
 
-EXPLAIN PRIVACY;
+EXPLAIN COMPLIANCE;

--- a/experiments/explain/shuup/no-pii.sql
+++ b/experiments/explain/shuup/no-pii.sql
@@ -26,8 +26,6 @@ CREATE TABLE shuup_personcontact ( \
   FOREIGN KEY (user_id) REFERENCES auth_user(ptr) \
 );
 
-CREATE INDEX auth_user_ptr ON auth_user(id);
-
 CREATE TABLE shuup_companycontact ( \
   contact_ptr_id int, \
   tax_number int, \
@@ -49,7 +47,6 @@ CREATE TABLE shuup_shop ( \
   PRIMARY KEY (id), \
   FOREIGN KEY (owner_id) REFERENCES auth_user(id) \
 );
-CREATE INDEX shuup_shop_id ON shuup_shop(id);
 
 CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   id int, \
@@ -61,4 +58,4 @@ CREATE TABLE shuup_gdpr_gdpruserconsent ( \
   PRIMARY KEY (id) \
 );
 
-EXPLAIN PRIVACY;
+EXPLAIN COMPLIANCE;

--- a/pelton/dataflow/ops/union.h
+++ b/pelton/dataflow/ops/union.h
@@ -20,8 +20,6 @@ class UnionOperator : public Operator {
   UnionOperator() : Operator(Operator::Type::UNION) {}
 
  protected:
-  bool DeepCompareSchemas(const SchemaRef s1, const SchemaRef s2);
-
   std::vector<Record> Process(NodeIndex source, std::vector<Record> &&records,
                               const Promise &promise) override;
 

--- a/pelton/explain.cc
+++ b/pelton/explain.cc
@@ -1,89 +1,105 @@
-// EXPLAIN PRIVACY command.
+// EXPLAIN COMPLIANCE command.
 #include "pelton/explain.h"
 
+#include <iomanip>
 #include <iostream>
+// NOLINTNEXTLINE
+#include <regex>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include "pelton/shards/state.h"
 
 namespace pelton {
 namespace explain {
 
-/*
 namespace {
 
-bool IsNullableSharding(const shards::UnshardedTableName &tbl,
-                        const shards::ShardingInformation &info,
+auto &out = std::cout;
+
+// Is the column that is used for this sharding (i.e. `info`) nullable. If so
+// the sharding could be nullable and lead to orphaned data.
+bool IsNullableSharding(const shards::TableName &tbl,
+                        const shards::ShardDescriptor &info,
                         const shards::SharderState &state) {
-  const shards::UnshardedTableName &table_name =
-      info.is_varowned() ? info.next_table : tbl;
+  const shards::TableName &table_name =
+      info.is_varowned() ? info.next_table() : tbl;
   const shards::ColumnName &column_name =
-      info.is_varowned() ? info.next_column : info.shard_by;
-  const auto &schema = state.GetSchema(table_name);
+      info.is_varowned() ? info.upcolumn() : info.downcolumn();
+  const auto &schema = state.GetTable(table_name).create_stmt;
   const auto &col = schema.GetColumn(column_name);
   bool ret = !col.HasConstraint(sqlast::ColumnConstraint::Type::NOT_NULL);
   return ret;
 }
 
-bool PrintTransitivityChain(
-    std::ostream &out, const shards::ShardingInformation &info,
-    const shards::SharderState &state, int indent,
-    std::vector<const shards::UnshardedTableName *> *varshards) {
-  const auto &transitive_infos =
-      state.GetShardingInformationFor(info.next_table, info.shard_kind);
-  const shards::ShardingInformation *tinfo_ptr = nullptr;
-  if (transitive_infos.size() == 0) {
-    LOG(FATAL) << "No next shardings for table: " << info.next_table
-               << ", shard kind: " << info.shard_kind
-               << ", column: " << info.next_column << " found.";
-  } else if (transitive_infos.size() == 1) {
-    tinfo_ptr = transitive_infos.front();
-  } else {
-    bool duplicate_found = false;
-    for (const auto *tinfo : transitive_infos) {
-      if (tinfo->distance_from_shard == info.distance_from_shard - 1) {
-        duplicate_found = tinfo_ptr != nullptr;
-        tinfo_ptr = tinfo;
+using ShardingChain =
+    std::vector<std::reference_wrapper<const shards::ShardDescriptor>>;
+using ShardingChainInfo = std::vector<ShardingChain>;
+
+/*
+ * Flatten out the tree of shards into individual paths. E.g.
+ *
+ *    A
+ *    |
+ *    B
+ *   / \
+ *  C   D
+ *
+ * Becomes the paths A->B->C and A->B->D
+ *
+ * Paths are stored in `results`. The last node in the results is a direct
+ * sharding, not the data subject table.
+ */
+void BuildShardingChains(const shards::ShardDescriptor &desc,
+                         const shards::SharderState &state,
+                         const ShardingChain &running_chain,
+                         ShardingChainInfo *results) {
+  const auto &table = state.GetTable(desc.next_table());
+  // The chain so far is taken by-ref from the prior call. Then we make a local
+  // copy that pushes this sharding to the end and hand that by-ref to the
+  // subsequewnt calls. We can't just mutably accumulate the chain because
+  // ther's recursive fan-out that would contend for the chain. Also the vectors
+  // are small and contain only references so copying is no big deal.
+  ShardingChain local_chain = running_chain;
+  local_chain.push_back(std::ref(desc));
+  if (desc.is_transitive() || desc.is_varowned()) {
+    for (const auto &tinfo : table.owners) {
+      if (tinfo->shard_kind != desc.shard_kind) {
+        continue;
       }
+      BuildShardingChains(*tinfo, state, local_chain, results);
     }
-    if (tinfo_ptr == nullptr) {
-      LOG(FATAL) << "Tried to disambiguate multiple candidate shardings for "
-                 << info.next_table
-                 << " using distance from shard but did not find a match, this "
-                    "is concerning!";
-    } else if (duplicate_found) {
-      LOG(WARNING)
-          << "Tried to disambiguate mutliple candidate shardings for "
-          << info.next_table
-          << " using distance from shard but found more than one match. The "
-             "following information may therefore be incorrect!";
-    }
+  } else {
+    // Desc is direct and so the next_table is the datasubject table.
+    CHECK_EQ(table.table_name, desc.shard_kind)
+        << "INVARIANT VIOLATED: the table " << table.table_name
+        << " is being directly sharded to via " << desc
+        << " (it should be a DATA_SUBJECT table)!";
+
+    // We're done. This must be a direct sharding so no reason to recurse. Also
+    // because the local chain is a local copy we can just move it.
+    results->push_back(std::move(local_chain));
   }
-
-  const auto &tinfo = *tinfo_ptr;
-  bool is_nullable = IsNullableSharding(info.next_table, tinfo, state);
-  if (tinfo.is_varowned()) varshards->push_back(&tinfo.next_table);
-  out << std::setw(indent) << ""
-      << "via " << info.next_table << "(" << tinfo.shard_by
-      << ") resolved with index " << info.next_index_name << std::endl;
-
-  if (tinfo.IsTransitive())
-    is_nullable = is_nullable ||
-                  PrintTransitivityChain(out, tinfo, state, indent, varshards);
-  return is_nullable;
 }
 
+// Matches column names for data that might be considered personal.
 const std::regex SUSPICIOUS_COLUMN_NAME_INDICATORS(
     "email|password|(first|last|middle|user)[-_]?name|gender",
     std::regex_constants::ECMAScript | std::regex_constants::icase |
         std::regex_constants::nosubs | std::regex_constants::optimize);
 
-void WarningsFromSchema(std::ostream &out, const sqlast::CreateTable &schema,
+// Emit warnigns that only relate to the schema (not the sharding). Currently
+// just matches for column names that may indicate personal data and alerts if
+// the table is not sharded and such columns have been found.
+void WarningsFromSchema(const sqlast::CreateTable &schema,
                         const bool is_sharded, const bool is_pii) {
   using col_name_match_size_t = std::string::const_iterator::difference_type;
   if (is_sharded || is_pii) return;
   std::vector<std::tuple<const std::string *, const col_name_match_size_t,
                          const col_name_match_size_t>>
-      suspicious_column_names{};
+      suspicious_column_names;
   for (const auto &col : schema.GetColumns()) {
     std::smatch match;
     bool matched = std::regex_search(col.column_name(), match,
@@ -111,99 +127,192 @@ void WarningsFromSchema(std::ostream &out, const sqlast::CreateTable &schema,
   }
 }
 
-using ShardingChainInfo =
-    std::vector<std::vector<const shards::UnshardedTableName *>>;
-
-std::pair<ShardingChainInfo, bool> GetAndReportShardingInformation(
-    std::ostream &out, const shards::UnshardedTableName &table_name,
-    const std::list<shards::ShardingInformation> &sharding_infos,
-    const shards::SharderState &state) {
-  ShardingChainInfo varown_chains{};
-  bool is_nullable = true;
-  for (const auto &info : sharding_infos) {
-    bool this_sharding_is_nullable =
-        IsNullableSharding(table_name, info, state);
-    std::vector<const shards::UnshardedTableName *> varown_chain{};
-    if (info.is_varowned()) varown_chain.push_back(&info.next_table);
-    out << "  " << info.shard_by << " shards to " << info.shard_kind
-        << std::endl;
-    if (info.IsTransitive()) {
-      this_sharding_is_nullable =
-          this_sharding_is_nullable ||
-          PrintTransitivityChain(out, info, state, 4, &varown_chain);
-      out << "    total transitive distance is " << info.distance_from_shard
-          << std::endl;
+// Print each sharding chain in human readable format.
+void ReportShardingInformation(const shards::TableName &table_name,
+                               const shards::SharderState &state,
+                               const ShardingChainInfo &chains) {
+  // The standard size of field to reserve for a column name
+  const int std_col_size = 20;
+  const auto &table_create_stmt = state.GetTable(table_name).create_stmt;
+  for (const auto &chain : chains) {
+    // We first print a subheader describing the shard kind and column in
+    // original table.
+    const auto &info = chain.front().get();
+    const auto &column = table_create_stmt.GetColumn(info.downcolumn());
+    std::string deduced = "implicitly deduced";
+    if (info.is_varowned()) {
+      // Variable ownerships are always explicit
+      deduced = "explicit annotation";
     }
-    if (varown_chain.size() > 0) varown_chains.push_back(varown_chain);
-    is_nullable = is_nullable && this_sharding_is_nullable;
+    using ColCons = sqlast::ColumnConstraint;
+    if (column.HasConstraint(ColCons::Type::FOREIGN_KEY)) {
+      const auto &cons = column.GetConstraintOfType(ColCons::Type::FOREIGN_KEY);
+      if (std::get<2>(cons.ForeignKey()) == ColCons::FKType::OWNED_BY) {
+        deduced = "explicit annotation";
+      }
+    }
+
+    // Print sub-header.
+    out << "  " << std::setiosflags(std::ios::left) << std::setw(std_col_size)
+        << info.downcolumn() << " shards to "
+        << std::setiosflags(std::ios::left) << std::setw(std_col_size)
+        << info.shard_kind << " (" << deduced << ")" << std::endl;
+
+    // Print the ownership chain.
+    std::string last_table = table_name;
+    for (const auto info_ref : chain) {
+      const auto &info = info_ref.get();
+      out << std::setw(6) << ""
+          << "via   ";
+      switch (info.type) {
+        case shards::InfoType::DIRECT:
+          out << last_table << "(" << info.downcolumn() << ") -> "
+              << info.next_table() << "(" << info.upcolumn() << ")";
+          break;
+        case shards::InfoType::TRANSITIVE:
+          out << last_table << "(" << info.downcolumn() << ") -> "
+              << info.next_table() << "(" << info.upcolumn() << ")";
+          break;
+        case shards::InfoType::VARIABLE:
+          out << last_table << "(" << info.downcolumn() << ") -> "
+              << info.next_table() << "(" << info.upcolumn() << ")";
+          break;
+        default:
+          LOG(FATAL) << "UNREACHABLE";
+      }
+      // << info->next_table() << "(" << tinfo.upcolumn() << ")";
+      out << std::endl;
+    }
+
+    if (chain.size() > 1)
+      out << "    with a total distance of " << chain.size() << std::endl;
   }
-  return std::make_pair(varown_chains, is_nullable);
 }
 
-void ClassifyAndWarnAboutSharding(
-    std::ostream &out, const ShardingChainInfo &varown_chains,
-    const std::list<shards::ShardingInformation> &sharding_infos,
-    const bool is_nullable) {
-  const std::vector<const shards::UnshardedTableName *> *longest_varown_chain =
-      nullptr;
+// Collate information about each sharding path (sharding chain) and the print
+// warnings based on this information. Currently we try to figure out how many
+// copies your annotations will cause to be stored and warn if either may be too
+// many of them, either due to chained variable ownership or due to too many
+// owner annotations on a table.
+void ClassifyAndWarnAboutSharding(const shards::TableName table_name,
+                                  const shards::SharderState &state,
+                                  const ShardingChainInfo &sharding_chains) {
+  using VarownChain =
+      std::vector<std::reference_wrapper<const shards::TableName>>;
+  bool is_always_nullable = true;
 
-  for (auto &varown_chain : varown_chains) {
-    if (!longest_varown_chain ||
-        longest_varown_chain->size() < varown_chain.size())
-      longest_varown_chain = &varown_chain;
+  std::vector<VarownChain> varown_chains;
+  for (const auto &sharding_chain : sharding_chains) {
+    // Tracks whether this chain has a nullable link
+    bool is_nullable = false;
+    // Tracks the variable ownership tables (the relationship tables) are in
+    // this chain
+    VarownChain varown_chain;
+    // Reference to the table we're currently looking at so that we can check if
+    // its sharding columns are nullable.
+    const shards::TableName *current_table = &table_name;
+    for (const auto &info : sharding_chain) {
+      if (info.get().is_varowned())
+        varown_chain.push_back(std::ref(info.get().next_table()));
+      is_nullable =
+          is_nullable || IsNullableSharding(*current_table, info, state);
+      current_table = &info.get().next_table();
+    }
+    is_always_nullable = is_always_nullable && is_nullable;
+    if (varown_chain.size() != 0) {
+      varown_chains.push_back(std::move(varown_chain));
+    }
   }
 
-  int regular_shardings = sharding_infos.size() - varown_chains.size();
-  int longest_varown_chain_size =
-      longest_varown_chain ? longest_varown_chain->size() : 0;
+  const size_t varown_shardings = varown_chains.size();
+  const size_t regular_shardings = sharding_chains.size() - varown_shardings;
+
+  VarownChain empty_varown_chain;
+  const auto &longest_chain_it =
+      std::max_element(varown_chains.begin(), varown_chains.end(),
+                       [](const auto &one, const auto &other) {
+                         return one.size() < other.size();
+                       });
+  const VarownChain &longest_varown_chain =
+      longest_chain_it == varown_chains.end() ? empty_varown_chain
+                                              : *longest_chain_it;
 
   // Feedback section
 
-  if (longest_varown_chain_size > 1) {
-    out << "  [SEVERE] This table is variably sharded "
-        << longest_varown_chain->size()
+  // At least one chain had multiple variable ownerships which can lead to a
+  // copy explosion, so we warn about it and print (the variable ownership
+  // tables in) the chain.
+  if (longest_varown_chain.size() > 1) {
+    out << "  [SEVERE]  This table is variably sharded "
+        << longest_varown_chain.size()
         << " times in sequence. This will create ";
     bool put_sym = false;
-    for (const auto &varown_table : *longest_varown_chain) {
+    for (const auto &varown_table : longest_varown_chain) {
       if (put_sym)
         out << '*';
       else
         put_sym = true;
-      out << *varown_table;
+      out << "|" << varown_table.get() << "|";
     }
     out << " copies of records inserted into this table. This is likely not "
-           "desired behavior, I suggest checking your `OWNS` annotations."
-        << std::endl;
+           "desired behavior, I suggest checking your `"
+        << sqlast::ForeignKeyTypeEnum::OWNS << "` annotations." << std::endl;
   }
-  if (varown_chains.size() > 1) {
+  // We detect there are multiple variable ownerships, but not necessarily in
+  // the same chain. This is also a code smell so we warn about it and print in
+  // each case the head of the variable ownership chain.
+  if (varown_shardings > 1) {
     out << "  [Warning] This table is variably owned in multiple ways (via ";
     bool put_sym = false;
     for (const auto &varown_tables : varown_chains) {
+      if (varown_tables.size() == 0) continue;
       if (put_sym)
         out << " and ";
       else
         put_sym = true;
-      out << *varown_tables.front();
+      out << varown_tables.front().get();
     }
     out << "). This may not be desired behavior." << std::endl;
-  } else if (varown_chains.size() == 1) {
-    out << "  [Info] this table is variably owned (via "
-        << *varown_chains.front().front() << ")" << std::endl;
   }
-  if (longest_varown_chain_size == 1 && regular_shardings > 1) {
+  if (varown_shardings == 1 && longest_varown_chain.size() == 1) {
+    // Only one variable ownership is detected, we report this not as a problem
+    // but as perhaps useful information. Since there is only one we know that
+    // also has to be the longest chain we found so we query that.
+    //
+    // We only report this if we haven't otherwise reported on variable
+    // ownership.
+    out << "  [Info]    This table is variably owned (via "
+        << longest_varown_chain.front().get() << ")" << std::endl;
+  }
+  if (longest_varown_chain.size() == 1 && regular_shardings > 1) {
+    // Copies in addition to variable ownership are a code smell so we report
+    // how much it is copied in addition. The determination that
+    // regular_shardings > 1 in addition to the varowns are where we draw the
+    // line is arbitrary.
     out << "  [Warning] This table is variably owned and also copied an "
-           "additional "
-        << regular_shardings << " times." << std::endl;
+        << "additional " << regular_shardings << " times." << std::endl;
   } else if (regular_shardings > 5) {
+    // Too many regular shardings are a code smell. The chosen threshold is
+    // arbitrary.
     out << "  [Warning] This table is sharded " << regular_shardings
-        << " times. This seem excessive, you may want to check your `OWNER` "
-           "annotations."
+        << " times. This seem excessive, you may want to check your `"
+        << sqlast::ForeignKeyTypeEnum::OWNED_BY << "`  annotations."
         << std::endl;
   } else if (regular_shardings > 2) {
-    out << "  [Info] This table is copied " << regular_shardings << " times"
+    // Multiple copies of this table will be made. That could very well be
+    // intended, but we report it as information in case it isn't.
+    out << "  [Info]    This table is copied " << regular_shardings << " times"
         << std::endl;
   }
-  if (is_nullable) {
+  if (is_always_nullable) {
+    // All paths leading to this datum are nullable. If these foreign keys are
+    // (accidentally) set to `NULL` this will store the data in the default
+    // shard and either cause a compiance violation error (if enabled) or the
+    // data may leak in this way so we always warn about it. If just one of the
+    // paths is non-nullable that is enough because that means if all nullable
+    // paths are set to `NULL` the data will still not go to the default shard,
+    // but to the last non-nullable shard and thus if that user says `GDPR
+    // FORGET` the data will be removed and not leak.
     out << "  [Warning] This table is sharded, but all sharding paths are "
            "nullable. This will lead to records being stored in a global table "
            "if those columns are NULL and could be a source of non-compliance."
@@ -212,36 +321,56 @@ void ClassifyAndWarnAboutSharding(
 }
 
 }  // namespace
-*/
 
-void ExplainPrivacy(const Connection &connection) {
+void ExplainCompliance(const Connection &connection) {
   const shards::SharderState &state = connection.state->SharderState();
 
-  std::cout << std::endl;
-  std::cout << std::endl;
-  std::cout << "############# EXPLAIN PRIVACY #############" << std::endl;
-  for (const auto &[table_name, table] : state.AllTables()) {
-    // Eventually also include if there are sharded tables that have a default
-    // table which is non-empty, shich could be a privacy violation
-    std::cout << " ----------------------------------------- " << std::endl;
-    std::cout << table_name << std::endl;
-    if (state.ShardKindExists(table_name)) {
-      std::cout << "  DATASUBJECT" << std::endl;
-    }
+  out << std::endl;
+  out << std::endl;
+  out << "############# EXPLAIN COMPLIANCE #############" << std::endl;
+  for (const auto &[table_name, table] : state.ReverseTables()) {
+    out << "----------------------------------------- " << std::endl;
+    out << table_name << ": ";
 
-    std::cout << "  OWNERS:" << std::endl;
-    for (const auto &descriptor : table.owners) {
-      std::cout << *descriptor << std::endl;
-    }
+    bool is_sharded = table->owners.size() != 0;
+    if (!is_sharded) {
+      out << "UNSHARDED" << std::endl;
+    } else {
+      // Might be a datasubject table, or a table owned by other datasubjects,
+      // or both.
+      if (state.ShardKindExists(table_name)) {
+        out << "DATASUBJECT";
+        if (table->owners.size() > 1) {
+          out << " AND SHARDED";
+        }
+        out << std::endl;
+      } else {
+        out << "SHARDED" << std::endl;
+      }
 
-    std::cout << "  ACCESSORS:" << std::endl;
-    for (const auto &descriptor : table.accessors) {
-      std::cout << *descriptor << std::endl;
+      // Collect information about the chains starting from this table.
+      ShardingChainInfo sharding_chains;
+      for (const auto &own : table->owners) {
+        if (own->shard_kind != table_name) {
+          ShardingChain initial_chain;
+          BuildShardingChains(*own, state, initial_chain, &sharding_chains);
+        }
+      }
+
+      if (sharding_chains.size() > 0) {
+        // Report statistics about the sharding itself
+        ReportShardingInformation(table_name, state, sharding_chains);
+        // Report violations arising from the sharding setup
+        ClassifyAndWarnAboutSharding(table_name, state, sharding_chains);
+      }
     }
+    // Report possible vialations that we can infer from the schema alone
+    WarningsFromSchema(table->create_stmt, is_sharded,
+                       state.ShardKindExists(table_name));
   }
-  std::cout << "############# END EXPLAIN PRIVACY #############" << std::endl;
-  std::cout << std::endl;
-  std::cout << std::endl;
+  out << "############# END EXPLAIN COMPLIANCE #############" << std::endl;
+  out << std::endl;
+  out << std::endl;
 }
 
 }  // namespace explain

--- a/pelton/explain.h
+++ b/pelton/explain.h
@@ -1,4 +1,4 @@
-// EXPLAIN PRIVACY command.
+// EXPLAIN COMPLIANCE command.
 #ifndef PELTON_EXPLAIN_H_
 #define PELTON_EXPLAIN_H_
 
@@ -7,7 +7,7 @@
 namespace pelton {
 namespace explain {
 
-void ExplainPrivacy(const Connection &connection);
+void ExplainCompliance(const Connection &connection);
 
 }  // namespace explain
 }  // namespace pelton

--- a/pelton/pelton.cc
+++ b/pelton/pelton.cc
@@ -49,8 +49,8 @@ std::optional<SqlResult> SpecialStatements(const std::string &sql,
       return SqlResult(true);
     }
   }
-  if (absl::StartsWith(sql, "EXPLAIN PRIVACY")) {
-    explain::ExplainPrivacy(*connection);
+  if (absl::StartsWith(sql, "EXPLAIN COMPLIANCE")) {
+    explain::ExplainCompliance(*connection);
     return SqlResult(true);
   }
   if (absl::StartsWith(sql, "EXPLAIN ")) {

--- a/pelton/proxy/src/proxy.rs
+++ b/pelton/proxy/src/proxy.rs
@@ -267,7 +267,7 @@ impl<W: io::Write> MysqlShim<W> for Backend {
        || q_string.starts_with("CREATE INDEX")
        || q_string.starts_with("CREATE VIEW")
        || q_string.starts_with("SET")
-       || q_string.starts_with("EXPLAIN PRIVACY")
+       || q_string.starts_with("EXPLAIN COMPLIANCE")
     {
       let ddl_response = pelton::exec_ddl(self.rust_conn, q_string);
       if ddl_response {

--- a/pelton/shards/BUILD.bazel
+++ b/pelton/shards/BUILD.bazel
@@ -28,5 +28,6 @@ cc_library(
     deps = [
         "//pelton/dataflow:schema",
         "//pelton/sqlast:ast",
+        "@glog",
     ],
 )

--- a/pelton/shards/state.h
+++ b/pelton/shards/state.h
@@ -81,8 +81,12 @@ class SharderState {
 
   // Debugging information / statistics.
   std::vector<std::pair<ShardKind, uint64_t>> NumShards() const;
-  const std::unordered_map<TableName, Table> &AllTables() const {
-    return this->tables_;
+  std::list<std::pair<TableName, const Table *>> ReverseTables() const {
+    std::list<std::pair<TableName, const Table *>> vec;
+    for (const auto &[table_name, table] : this->tables_) {
+      vec.emplace_front(table_name, &table);
+    }
+    return vec;
   }
 
  private:

--- a/pelton/sql/rocksdb/connection_schema.cc
+++ b/pelton/sql/rocksdb/connection_schema.cc
@@ -31,6 +31,11 @@ bool RocksdbConnection::ExecuteCreateTable(const sqlast::CreateTable &stmt) {
 
   // Create indices for table.
   for (size_t i = 0; i < stmt.GetColumns().size(); i++) {
+    // Primary key already has index created for it.
+    if (i == schema.keys().front()) {
+      continue;
+    }
+    // For non-PK columns, we create an index automatically if unique or FK.
     const auto &column = stmt.GetColumns().at(i);
     for (const auto &cnstr : column.GetConstraints()) {
       switch (cnstr.type()) {

--- a/pelton/sqlast/ast_schema.cc
+++ b/pelton/sqlast/ast_schema.cc
@@ -130,6 +130,11 @@ bool CreateTable::HasColumn(const std::string &column_name) const {
   return this->columns_map_.count(column_name) == 1;
 }
 
+const ColumnDefinition &CreateTable::GetColumn(
+    const std::string &column_name) const {
+  return this->columns_.at(this->columns_map_.at(column_name));
+}
+
 void CreateTable::AddAnonymizeRule(AnonymizationRule &&anon_rule) {
   this->anon_rules_.push_back(std::move(anon_rule));
 }
@@ -152,6 +157,23 @@ std::ostream &operator<<(std::ostream &os, const ColumnDefinition::Type &r) {
     os << ColumnDefinition::TypeToString(r);
   }
   return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const ColumnConstraint::FKType &t) {
+  switch (t) {
+    case ForeignKeyTypeEnum::OWNED_BY:
+      return os << "OWNED_BY";
+    case ForeignKeyTypeEnum::OWNS:
+      return os << "OWNS";
+    case ForeignKeyTypeEnum::ACCESSED_BY:
+      return os << "ACCESSED_BY";
+    case ForeignKeyTypeEnum::ACCESSES:
+      return os << "ACCESSES";
+    case ForeignKeyTypeEnum::AUTO:
+      return os << "AUTO";
+    case ForeignKeyTypeEnum::PLAIN:
+      return os << "PLAIN";
+  }
 }
 
 }  // namespace sqlast

--- a/pelton/sqlast/ast_schema.h
+++ b/pelton/sqlast/ast_schema.h
@@ -199,6 +199,7 @@ class CreateTable : public AbstractStatement {
   // Column manipulations.
   void AddColumn(const std::string &column_name, const ColumnDefinition &def);
   const std::vector<ColumnDefinition> &GetColumns() const;
+  const ColumnDefinition &GetColumn(const std::string &column_name) const;
   ColumnDefinition &MutableColumn(const std::string &column_name);
   bool HasColumn(const std::string &column_name) const;
 
@@ -328,6 +329,7 @@ class CreateView : public AbstractStatement {
 
 std::ostream &operator<<(std::ostream &os, const ColumnConstraint::Type &r);
 std::ostream &operator<<(std::ostream &os, const ColumnDefinition::Type &r);
+std::ostream &operator<<(std::ostream &os, const ColumnConstraint::FKType &t);
 
 }  // namespace sqlast
 }  // namespace pelton

--- a/pelton/sqlast/ast_schema_enums.h
+++ b/pelton/sqlast/ast_schema_enums.h
@@ -9,6 +9,7 @@ enum ColumnConstraintTypeEnum {
   PRIMARY_KEY,
   UNIQUE,
   FOREIGN_KEY,
+  NOT_NULL,
 };
 enum ForeignKeyTypeEnum {
   OWNED_BY,

--- a/pelton/sqlast/transformer.cc
+++ b/pelton/sqlast/transformer.cc
@@ -196,7 +196,7 @@ antlrcpp::Any AstTransformer::visitColumn_constraint(
   }
   if (ctx->NOT() != nullptr) {
     std::cout << "Warning: NOT NULL constraint not enforced" << std::endl;
-    return {};
+    return ColumnConstraint::Make(ColumnConstraint::Type::NOT_NULL);
   }
 
   if (ctx->PRIMARY() != nullptr) {


### PR DESCRIPTION
This PR ports `EXPLAIN COMPLIANCE` to the new metadata format. 

A quick example for the `experiments/explain/shuup/contact-is-pii.sql` schema

```
############# EXPLAIN PRIVACY #############
----------------------------------------- 
shuup_shop: SHARDED
  owner_id             shards to shuup_contact        (explicit annotation)
      via   auth_user(user_id)
      via   shuup_personcontact(id)
    with a total distance of 3
  [Info]    This table is variably owned (via shuup_personcontact)
  [Warning] This table is sharded, but all sharding paths are nullable. This will lead to records being stored in a global table if those columns are NULL and could be a source of non-compliance.
----------------------------------------- 
shuup_companycontact_members: SHARDED
  companycontact_id    shards to shuup_contact        (implicitly deduced)
      via   shuup_companycontact(id)
    with a total distance of 2
----------------------------------------- 
shuup_companycontact: SHARDED
  contact_ptr_id       shards to shuup_contact        (implicitly deduced)
----------------------------------------- 
shuup_gdpr_gdpruserconsent: SHARDED
  user_id              shards to shuup_contact        (explicit annotation)
      via   auth_user(user_id)
      via   shuup_personcontact(id)
    with a total distance of 3
  [Info]    This table is variably owned (via shuup_personcontact)
  [Warning] This table is sharded, but all sharding paths are nullable. This will lead to records being stored in a global table if those columns are NULL and could be a source of non-compliance.
----------------------------------------- 
shuup_personcontact: SHARDED
  contact_ptr_id       shards to shuup_contact        (implicitly deduced)
----------------------------------------- 
shuup_contact: DATASUBJECT
----------------------------------------- 
auth_user: SHARDED
  id                   shards to shuup_contact        (explicit annotation)
      via   shuup_personcontact(id)
    with a total distance of 2
  [Info]    This table is variably owned (via shuup_personcontact)
  [Warning] This table is sharded, but all sharding paths are nullable. This will lead to records being stored in a global table if those columns are NULL and could be a source of non-compliance.
############# END EXPLAIN PRIVACY #############
```

It restores most of the old functionality with the following exceptions:

- Used indices are no longer reported. This is an executive decision I made because the index names that are now used aren't helpful (e.g. `_index_1` and so on).
- It now reports whether a sharding comes from an explicit annotation or was implicitly deduced by pelton.
- Distances reported are now the entire distance of the sharding "hops". Printing this information is elided for direct sharding (distance 1)
- Added some alignment to hopefully make tables with lots of sharding information more readable

In terms of testing I ran this against all examples in `experiments/explain` and made sure it creates the same output (modulo the changes outlined). I couldn't run it against ownCloud because of #151 